### PR TITLE
Smooch: Updates for compatibility with Smooch SDK 6.0.

### DIFF
--- a/SmoochHelpKit/Source/SHKSettings.m
+++ b/SmoochHelpKit/Source/SHKSettings.m
@@ -21,8 +21,7 @@
 
 +(instancetype)settingsWithAppToken:(NSString*)appToken
 {
-    SHKSettings* settings = [[SHKSettings alloc] init];
-    settings.appToken = appToken;
+    SHKSettings* settings = [SHKSettings settingsWithAppToken:appToken];
     return settings;
 }
 

--- a/SmoochHelpKit/Source/SmoochHelpKit.m
+++ b/SmoochHelpKit/Source/SmoochHelpKit.m
@@ -48,9 +48,9 @@ static NSString* const kSmoochWasLaunched = @"SKTSupportKitWasLaunched";
         NSLog(@"<Smooch: ERROR> Init called more than once, aborting init sequence!");
     }else{
         settings = newSettings;
-        
-        [Smooch initWithSettings:settings];
-        
+
+        [Smooch initWithSettings:settings completionHandler:NULL];
+
         if (appDidFinishLaunching) {
             [self completeInit];
         }else{


### PR DESCRIPTION
Smooch is deprecating support of Smooch iOS SDK 5.X. Upon updating to Smooch 6.0, the following changes were required to maintain compatibility.

- Instantiate instance of `SHKSettings` with `[SHKSettings settingsWithAppToken(NSString *)]`
- Initialize `Smooch` with `[Smooch initWithSettings(SHKSettings* ) competionHandler]`